### PR TITLE
Pass option to `initdb` to default text encoding to UTF-8

### DIFF
--- a/tmdeploy/share/playbooks/tissuemaps/roles/database-server-common/tasks/create_cluster.yml
+++ b/tmdeploy/share/playbooks/tissuemaps/roles/database-server-common/tasks/create_cluster.yml
@@ -85,7 +85,7 @@
     - database
 
 - name: Initialize database cluster
-  command: /usr/local/sbin/su-exec {{ db_user }} {{ db_executable_directory }}/pg_ctl init -D {{ db_data_directory }}/{{ db_node }} -l {{ db_log_directory }}/postgresql-{{ db_node }}.log
+  command: /usr/local/sbin/su-exec {{ db_user }} {{ db_executable_directory }}/pg_ctl init -D {{ db_data_directory }}/{{ db_node }} -l {{ db_log_directory }}/postgresql-{{ db_node }}.log -o '--locale=C.UTF-8'
   args:
     chdir: "{{ db_data_directory }}"
   when:


### PR DESCRIPTION
It can happen that the OME-XML string extracted from microscopy files is not pure ASCII.

However, if the database has been created with `SQL_ASCII` character set, PostgreSQL does not allow using string encodings other than `ascii`.

Now, the DB-wide character set can only be specified at `initdb` time and the default is to take it from the locale that `initdb` runs in.  We therefore override this choice by forcing `initdb` to create the DB with the `C.UTF-8` locale which is just the standard UNIX/Linux locale but with the UTF-8 character set.

This fixes errors later in the ingestion phase where a Python traceback is raised because SqlAlchemy cannot insert (valid) UTF-8 strings into the `omexml` column.  (But none of this is apparent from the traceback, thanks to @sparkvilla for digging into the issue!)