### PR TITLE
Update ``compute`` role for changed ``jtlibrary`` repo

### DIFF
--- a/etc/cluster_setup_ec2.yml
+++ b/etc/cluster_setup_ec2.yml
@@ -26,9 +26,9 @@ architecture:
             - name: glusterfs_client
             - name: ganglia_monitor
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: M4.2xlarge
+            flavor: m4.2xlarge
             tags:
               - web
               - compute
@@ -43,9 +43,9 @@ architecture:
             - name: glusterfs_client
             - name: ganglia_monitor
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: C4.xlarge
+            flavor: c4.xlarge
             tags:
               - compute
 
@@ -60,9 +60,9 @@ architecture:
                 db_master_memory: 29000
             - name: ganglia_monitor
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: I3.xlarge
+            flavor: i3.xlarge
             volume_size: 950
             tags:
               - storage
@@ -76,9 +76,9 @@ architecture:
                 db_worker_memory: 29000
             - name: ganglia_monitor
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: I3.xlarge
+            flavor: i3.xlarge
             volume_size: 950
             tags:
               - storage
@@ -91,9 +91,9 @@ architecture:
             - name: glusterfs_server
             - name: ganglia_monitor
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: M4.xlarge
+            flavor: m4.xlarge
             volume_mountpoint: /srv/glusterfs
             volume_size: 2000
             tags:
@@ -106,9 +106,9 @@ architecture:
           groups:
             - name: ganglia_master
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: 2cpu-2ram-server
+            flavor: t2.medium
             tags:
               - web
               - compute

--- a/etc/standalone_setup_ec2.yml
+++ b/etc/standalone_setup_ec2.yml
@@ -29,9 +29,9 @@ architecture:
                 db_worker_cores: 1
                 db_worker_memory: 3625
           instance:
-            image: ami-fa2df395
+            image: ami-7cbc6e13 #ami-fa2df395
             ssh_user: centos
-            flavor: M4.2xlarge
+            flavor: m4.2xlarge
             volume_size: 1000
             tags:
               - web

--- a/tmdeploy/share/playbooks/tissuemaps/roles/compute/tasks/tissuemaps.yml
+++ b/tmdeploy/share/playbooks/tissuemaps/roles/compute/tasks/tissuemaps.yml
@@ -57,31 +57,6 @@
   tags:
     - tissuemaps
 
-- name: Clone JtModules repository
-  git:
-    repo: "{{ tm_github_url }}/jtmodules"
-    dest: "{{ tm_home }}/jtmodules"
-    version: "{{ tm_version }}"
-    force: yes
-  tags:
-    - tissuemaps
-
-- name: Install jtmodules package dependencies
-  shell: PYTHONUSERBASE={{ tm_home }}/.local pip install -r {{ tm_home }}/jtmodules/requirements.txt --user --no-cache-dir
-  args:
-    chdir: "{{ tm_home }}/jtmodules/"
-    executable: /bin/bash
-  tags:
-    - tissuemaps
-
-- name: Install jtmodules package
-  shell: PYTHONUSERBASE={{ tm_home }}/.local pip install -e {{ tm_home }}/jtmodules --user --no-cache-dir
-  args:
-    chdir: "{{ tm_home }}/jtmodules/"
-    executable: /bin/bash
-  tags:
-    - tissuemaps
-
 - name: Clone TmLibrary repository
   git:
     repo: "{{ tm_github_url }}/tmlibrary"


### PR DESCRIPTION
The obsolete ``jtmodules`` repository is no longer cloned and the ``jtmodules`` python package no longer installed.