### PR TITLE
Fix problem with building containers

### DIFF
--- a/bin/tm_deploy
+++ b/bin/tm_deploy
@@ -296,7 +296,8 @@ def push_container(args):
 
 def main(args):
     # sanitize command-line args
-    args.setup_file = os.path.abspath(os.path.expanduser(args.setup_file))
+    if args.env == 'vm':
+        args.setup_file = os.path.abspath(os.path.expanduser(args.setup_file))
 
     # redirect to actual code
     context = globals()


### PR DESCRIPTION
With Riccardo's latest fix, the environment variable setup_file was already changed in the main. The setup_file variable is not used when building containers, thus leading to an error because the main function called a non existing args. Thus this workaround ensures that Riccardos fix is only applied to the VM branch of tm_deploy