### PR TITLE
gc3pie.conf: Use same convention for max memory in both `localhost` and `cluster` resources.

### DIFF
--- a/tmdeploy/share/playbooks/tissuemaps/roles/app-server/templates/gc3pie.conf.j2
+++ b/tmdeploy/share/playbooks/tissuemaps/roles/app-server/templates/gc3pie.conf.j2
@@ -23,6 +23,5 @@ auth=noauth
 architecture=x86_64
 max_cores={{ tm_compute_cores|int * tm_compute_nodes|int }}
 max_cores_per_job={{ tm_compute_cores }}
-max_memory_per_core={{ (tm_compute_memory|int / tm_compute_cores|int)|round(0, 'floor')|int }} MB
+max_memory_per_core={{ (tm_compute_memory }} MB
 max_walltime=10 days
-


### PR DESCRIPTION
This needs to be paired with commit 56f1ba23cdfa07d95a37aefee5426708f95f8a62 of `TmLibrary`.